### PR TITLE
Include DLL in package

### DIFF
--- a/DocRaptor.nuspec
+++ b/DocRaptor.nuspec
@@ -17,4 +17,8 @@
       <dependency id="Newtonsoft.Json" version="8.0.2" />
     </dependencies>
   </metadata>
+  <files>
+    <file src="README.md" target="" />
+    <file src="bin/DocRaptor.dll" target="lib" />
+  </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This is a DLL and NuGet package for using [DocRaptor API](https://docraptor.com/documentation) to convert [HTML to PDF and XLSX](https://docraptor.com).
 
+## Frameworks supported
+- .NET 4.0 or later
+- Windows Phone 7.1 (Mango)
+
+## Dependencies
+- [RestSharp](https://www.nuget.org/packages/RestSharp) - 105.1.0 or later
+- [Json.NET](https://www.nuget.org/packages/Newtonsoft.Json/) - 7.0.0 or later
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The generated client needed a few fixes
 7. Push to GitHub
 8. Tag version: `git tag 'vX.Y.Z' && git push --tags`
 9. Build package using `script/build`
-10. `mono vendor/nuget.exe push bin/DocRaptor.X.Y.Z.nupkg`
+10. `script/nuget push bin/DocRaptor.X.Y.Z.nupkg`
 11. Open https://github.com/DocRaptor/docraptor-csharp/tags and make a new release for the version. Use the git tag as the name, CHANGELOG entries as the description, and attach `bin/*.dll` to the release
 12. Refresh documentation on docraptor.com
 

--- a/script/build
+++ b/script/build
@@ -10,7 +10,7 @@ fi
 which mono > /dev/null || (echo "mono must be installed"; exit 1)
 which mcs > /dev/null  || (echo "mcs must be installed"; exit 1)
 
-mono vendor/nuget.exe install vendor/packages.config -o vendor
+script/nuget install vendor/packages.config -o vendor
 mkdir -p bin
 
 references=vendor/Newtonsoft.Json.8.0.2/lib/net45/Newtonsoft.Json.dll,vendor/RestSharp.105.2.3/lib/net45/RestSharp.dll,System.Runtime.Serialization.dll
@@ -22,7 +22,7 @@ mcs -sdk:45 \
   -doc:bin/DocRaptor.xml \
   -platform:anycpu
 
-mono vendor/nuget.exe pack -OutputDirectory bin/
+script/nuget pack -OutputDirectory bin/
 
 link=`echo $references | sed 's/,/ /g' | sed -E 's/ System\..*\.dll//'`
 mono vendor/ILRepack.exe /internalize /out:bin/DocRaptorWithDependencies.dll bin/DocRaptor.dll $link

--- a/script/nuget
+++ b/script/nuget
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd "`dirname \"$0\"`/.."
+
+mono vendor/nuget.exe $@


### PR DESCRIPTION
Looks like we were missing a file inclusion line in our nuspec file. So our packages didn't include a DLL at all. This was easily fixed but still needs verifying from an outside .NET user.

[docraptor-0.3.0-nupkg.zip](https://github.com/DocRaptor/docraptor-csharp/files/174573/docraptor-0.3.0-nupkg.zip)

I've also updated the README to include a bit more about supported frameworks and dependencies.
