### PR TITLE
Update RestSharp dependency to 105.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.1 [June 7, 2017]
+* Update RestSharp Dependency to 105.2.3
+
 ### 1.1.0 [November 3, 2016]
 * Added support for the pipeline API parameter
 

--- a/DocRaptor.nuspec
+++ b/DocRaptor.nuspec
@@ -3,9 +3,9 @@
   <metadata>
     <id>DocRaptor</id>
     <title>DocRaptor</title>
-    <version>1.1.0</version>
-    <authors>Elijah Miller</authors>
-    <owners>Elijah Miller</owners>
+    <version>1.1.1</version>
+    <authors>Expected Behavior</authors>
+    <owners>Expected Behavior</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <projectUrl>https://github.com/docraptor/docraptor-csharp</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a DLL and NuGet package for using [DocRaptor API](https://docraptor.com/
 - Windows Phone 7.1 (Mango)
 
 ## Dependencies
-- [RestSharp](https://www.nuget.org/packages/RestSharp) - 105.1.0 or later
+- [RestSharp](https://www.nuget.org/packages/RestSharp) - 105.2.3 or later
 - [Json.NET](https://www.nuget.org/packages/Newtonsoft.Json/) - 7.0.0 or later
 
 

--- a/src/main/csharp/DocRaptor/Client/Configuration.cs
+++ b/src/main/csharp/DocRaptor/Client/Configuration.cs
@@ -68,7 +68,7 @@ namespace DocRaptor.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "1.1.0";
+        public const string Version = "1.1.1";
 
         /// <summary>
         /// Gets or sets the default Configuration.
@@ -267,7 +267,7 @@ namespace DocRaptor.Client
                      .GetReferencedAssemblies()
                      .Where(x => x.Name == "System.Core").First().Version.ToString()  + "\n";
             report += "    Version of the API: 1.2.0\n";
-            report += "    SDK Package Version: 1.1.0\n";
+            report += "    SDK Package Version: 1.1.1\n";
 
             return report;
         }

--- a/src/main/csharp/DocRaptor/Properties/AssemblyInfo.cs
+++ b/src/main/csharp/DocRaptor/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyVersion("1.1.1")]
+[assembly: AssemblyFileVersion("1.1.1")]

--- a/swagger-config.json
+++ b/swagger-config.json
@@ -1,4 +1,4 @@
 {
 	"packageName": "DocRaptor",
-  "packageVersion": "1.1.0"
+  "packageVersion": "1.1.1"
 }

--- a/vendor/packages.config
+++ b/vendor/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net45" developmentDependency="true" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Previously, 105.1.0 and 105.2.3 were specified in different places, which was confusing and which complicated setup.  This simplifies and standardizes.

I can't think of any reason not to just standardize on the newer version.

This should not impact built and released clients, and should be completely transparent to users.